### PR TITLE
Hook init and postInit more cleanly

### DIFF
--- a/src/io/github/mcalphadev/mixin/MinecraftMixin.java
+++ b/src/io/github/mcalphadev/mixin/MinecraftMixin.java
@@ -10,14 +10,13 @@ import net.minecraft.client.Minecraft;
 
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
-	@Inject(at = @At("HEAD"), method = "catchGLError")
-	private void injectModInit(String phase, CallbackInfo info) {
-		if (phase.endsWith("tup")) {
-			if (phase.equals("Startup")) {
-				AlphaModLoader.getInstance().initialise();
-			} else if (phase.equals("Post startup")) {
-				AlphaModLoader.getInstance().postInitialise();
-			}
-		}
+	@Inject(at = @At(value = "CONSTANT", args = "stringValue=Startup"), method = "initialise")
+	private void injectModInit(CallbackInfo info) {
+		AlphaModLoader.getInstance().initialise();
+	}
+
+	@Inject(at = @At(value = "CONSTANT", args = "stringValue=Post startup"), method = "initialise")
+	private void injectModPosInit(CallbackInfo info) {
+		AlphaModLoader.getInstance().postInitialise();
 	}
 }


### PR DESCRIPTION
`Minecraft#catchGLError` is called twice a frame for pre- and postRender, so it would be ideal to not hook that for mod initialising. This puts the hooks in the same place but injecting into `Minecraft#initialise` instead.